### PR TITLE
More flexible solution to disable smooth scroll

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -9,7 +9,7 @@ jQuery(document).ready(function ($) {
 
     // Smooth Scroll
     $(function () {
-        $('a[href*="#"]:not([href="#"]):not([href="#tab-reviews"]):not([href="#tab-additional_information"]):not([href="#tab-description"]):not([href="#reviews"]):not([href="#carouselExampleIndicators"])').click(function () {
+        $('a[href*="#"]:not([href="#"]):not([href="#tab-reviews"]):not([href="#tab-additional_information"]):not([href="#tab-description"]):not([href="#reviews"]):not([href="#carouselExampleIndicators"])'):not([data-smoothscroll="false"]).click(function () {
             if (location.pathname.replace(/^\//, '') == this.pathname.replace(/^\//, '') && location.hostname == this.hostname) {
                 var target = $(this.hash);
                 target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');


### PR DESCRIPTION
I thought that a more clean solution to disable smooth scroll behaviour to some links could be done using a data attribute.
Example
```html
<a href="#internal-link-without-smooth-scroll" data-smoothscroll="false">Hello</a>
```

What do you think?